### PR TITLE
Add Ano to May 21 edition

### DIFF
--- a/editions/2026.05.21.md
+++ b/editions/2026.05.21.md
@@ -13,7 +13,7 @@
 ## ✨ Apps
 
 ### [Ano](https://ano.chat/)
-A local-first Slack alternative for small teams and vibe-coders. Built entirely on Rocicorp's Zero sync engine and Postgres, it offers sub-millisecond channel switching, instant multi-device sync, and fully offline-first reliability. Features native, collaborative Claude Code integration so teams and AI coworkers can build and ship together directly inside any channel.
+A local-first Slack alternative for small teams and devs. Built entirely on Rocicorp's Zero sync engine and Postgres, it offers sub-millisecond channel switching, instant multi-device sync, and zero-latency responsiveness. Features a collaborative shell directly inside the app with integrated AI (like Claude Code or any other agent), letting teams build and trigger custom automations, run any CLI, and connect to any MCP server.
 
 
 ## How to Contribute

--- a/editions/2026.05.21.md
+++ b/editions/2026.05.21.md
@@ -12,7 +12,8 @@
 
 ## ✨ Apps
 
-
+### [Ano](https://ano.chat/)
+A local-first Slack alternative for small teams and vibe-coders. Built entirely on Rocicorp's Zero sync engine and Postgres, it offers sub-millisecond channel switching, instant multi-device sync, and fully offline-first reliability. Features native, collaborative Claude Code integration so teams and AI coworkers can build and ship together directly inside any channel.
 
 
 ## How to Contribute


### PR DESCRIPTION
Added Ano under the Apps section. It is a local-first Slack alternative built on Rocicorp's Zero sync engine. Features a collaborative shell directly inside the app with integrated AI (like Claude Code or any other agent), letting teams build and trigger custom automations, run any CLI, and connect to any MCP server.